### PR TITLE
feat: add first_contribution_greeting workflow

### DIFF
--- a/.github/workflows/first_contribution_greeting.yml
+++ b/.github/workflows/first_contribution_greeting.yml
@@ -1,0 +1,31 @@
+# This action is meant to greet the developer and congratulate them for their first PR published
+# Also, the greet will remind the developer to check out the Contributing Guidelines and how to
+# actually fill the PR.
+name: First contribution greeting
+
+# Controls when the workflow will run
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
+
+jobs:
+  first-contribution-greeting:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/first-interaction@v1.1.1
+        with:
+          repo-token: ${{ secrets.GH_TOKEN }}
+          pr-message: |-
+            # 🎉 Thanks for opening your first Pull Request! 🎉
+            Take a moment to make sure the PR is in line with our [Contributing Guidelines](CONTRIBUTING.md).
+
+            As a quick reminder/TL;DR:
+            - PR titles and commit messages should follow the convention
+            - Either if it's a fix or a feature, remember to add evidence of the changes (screenshots, videos, test runs, etc.)
+            - Ask your squad teammates to review your changes
+            - Don't forget to assign the PR to yourself in the assignee entry on the right
+            - After the PR is approved, ask if it should be further tested by QA and deploy or create builds for them
+            - Last but not least, always use `squash and merge` for PR merging against our default development branch

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,3 +2,5 @@
 
 This file consists of the Table of Contents for the Documentation hosted
 on this repository.
+
+- [First Contribution Greeting](./first_contribution_greeting.md)

--- a/docs/first_contribution_greeting.md
+++ b/docs/first_contribution_greeting.md
@@ -1,0 +1,34 @@
+## Description
+
+Add `first_contribution_greeting` workflow to be reused and greet contributors on opening their first PR.
+
+Additionally, they will be reminded by it to follow the contributing guidelines of their repo.
+
+## Usage
+
+### Requirements
+
+Have in your repository a secret created containing your Personal Access Token
+for GitHub. If you need guidance on this step, please refer to the main
+[README.md](./README.md#GitHub-Secrets) on the docs folder of this repo.
+
+For more info on reusable workflows please check this
+[GitHub Doc](https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow).
+
+### Calling the workflow from one of your own
+
+```yaml
+...
+jobs:
+  my-job:
+    uses: juanmanso/dx-workflows/.github/workflows/first_contribution_greeting@main
+    secrets:
+      GH_TOKEN: ${{ secret.NAME_OF_YOUR_LOCAL_SECRET_TOKEN }}
+...
+```
+
+## Test
+
+| _Test run with new repository_ |
+| :---: |
+| <video src='https://user-images.githubusercontent.com/21087992/203149044-c12f3166-ac01-413c-8a5a-875f8ef14251.mov'> |


### PR DESCRIPTION
# Description

Add `first_contribution_greeting` workflow to be reused and greet contributors on opening their first PR.

Additionally, they will be reminded by it to follow the contributing guidelines of their repo.

# Test

| _Test run with new repository_ |
| :---: |
| <video src='https://user-images.githubusercontent.com/21087992/203149044-c12f3166-ac01-413c-8a5a-875f8ef14251.mov'> |


